### PR TITLE
解决在onnxruntime版本为1.14.1报错 

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,9 @@ class Informative_Drawings():
             print('opencv read onnx failed!!!')
         so = onnxruntime.SessionOptions()
         so.log_severity_level = 3
-        self.net = onnxruntime.InferenceSession(modelpath, so)
+        # providers_list = ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider']
+        providers_list = ['CPUExecutionProvider']
+        self.net = onnxruntime.InferenceSession(modelpath, so,providers = providers_list)
         input_shape = self.net.get_inputs()[0].shape
         self.input_height = int(input_shape[2])
         self.input_width = int(input_shape[3])


### PR DESCRIPTION
需要在onnxruntime后加上参数providers 最好直接用cpu 使用Tensorrt后端转化的速度可能有点慢 直接用cpu对于普通测试效果已经满足